### PR TITLE
removing is.rt from tests to prevent warning

### DIFF
--- a/tests/testthat/test-secuTrial.R
+++ b/tests/testthat/test-secuTrial.R
@@ -82,7 +82,7 @@ test_that("Test center retrieval", {
 })
 
 # test rectangular table loading
-load.tables(data.dir=system.file("extdata", "s_export_rt-CSV-xls_DEM00_20181016-151332.zip", package = "secuTrial"), is.rt = T, decode.rt.visitlabels = T)
+load.tables(data.dir=system.file("extdata", "s_export_rt-CSV-xls_DEM00_20181016-151332.zip", package = "secuTrial"), decode.rt.visitlabels = T)
 
 # test dimensions
  test_that("Bone mineral density dataset (rectangular) has the correct dimensions", {


### PR DESCRIPTION
If you merge this into your fork I thing it should be added to the PR on the SCTO repo. Once you have merged this I think we are good to go on your PR.